### PR TITLE
feat: implement Phase 0 — auth APIs, properties CRUD, and core frontend

### DIFF
--- a/backend/apps/accounts/permissions.py
+++ b/backend/apps/accounts/permissions.py
@@ -1,0 +1,56 @@
+"""RBAC permission classes for RentTrack."""
+from rest_framework.permissions import BasePermission
+
+from apps.accounts.models import Membership
+
+
+class IsOrgMember(BasePermission):
+    """Allows access if the user has an active membership in the org context."""
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        org_id = getattr(request.user, "active_organization_id", None)
+        if not org_id:
+            return False
+        return Membership.objects.filter(
+            user=request.user,
+            organization_id=org_id,
+            is_active=True,
+        ).exists()
+
+
+class IsOrgOwner(BasePermission):
+    """Allows access only to org owners."""
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        org_id = getattr(request.user, "active_organization_id", None)
+        if not org_id:
+            return False
+        return Membership.objects.filter(
+            user=request.user,
+            organization_id=org_id,
+            role=Membership.Role.OWNER,
+            is_active=True,
+        ).exists()
+
+
+class IsOrgOwnerOrManager(BasePermission):
+    """Allows owners and property managers."""
+
+    ALLOWED_ROLES = {Membership.Role.OWNER, Membership.Role.PROPERTY_MANAGER}
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        org_id = getattr(request.user, "active_organization_id", None)
+        if not org_id:
+            return False
+        return Membership.objects.filter(
+            user=request.user,
+            organization_id=org_id,
+            role__in=self.ALLOWED_ROLES,
+            is_active=True,
+        ).exists()

--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -1,0 +1,109 @@
+"""Serializers for accounts: signup, user profile, org, invite."""
+from django.contrib.auth.password_validation import validate_password
+from django.db import transaction
+from django.utils.text import slugify
+from rest_framework import serializers
+
+from apps.accounts.models import Membership, Organization, User
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = ["id", "name", "slug", "tier", "primary_email", "primary_phone", "gstin", "pan"]
+        read_only_fields = ["id", "slug", "tier"]
+
+
+class MembershipSerializer(serializers.ModelSerializer):
+    organization = OrganizationSerializer(read_only=True)
+
+    class Meta:
+        model = Membership
+        fields = ["id", "organization", "role", "is_active", "created_at"]
+        read_only_fields = ["id", "is_active", "created_at"]
+
+
+class UserSerializer(serializers.ModelSerializer):
+    memberships = MembershipSerializer(many=True, read_only=True)
+    active_organization = OrganizationSerializer(read_only=True)
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "phone",
+            "phone_verified",
+            "email_verified",
+            "active_organization",
+            "memberships",
+        ]
+        read_only_fields = ["id", "email", "phone_verified", "email_verified"]
+
+
+class SignupSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True, min_length=10)
+    first_name = serializers.CharField(max_length=150)
+    last_name = serializers.CharField(max_length=150, required=False, default="")
+    org_name = serializers.CharField(max_length=200)
+
+    def validate_email(self, value):
+        if User.objects.filter(email__iexact=value).exists():
+            raise serializers.ValidationError("An account with this email already exists.")
+        return value.lower()
+
+    def validate_password(self, value):
+        validate_password(value)
+        return value
+
+    @transaction.atomic
+    def save(self):
+        data = self.validated_data
+        user = User.objects.create_user(
+            email=data["email"],
+            password=data["password"],
+            first_name=data["first_name"],
+            last_name=data["last_name"],
+        )
+        base_slug = slugify(data["org_name"])
+        slug = base_slug
+        counter = 1
+        while Organization.objects.filter(slug=slug).exists():
+            slug = f"{base_slug}-{counter}"
+            counter += 1
+
+        org = Organization.objects.create(
+            name=data["org_name"],
+            slug=slug,
+            primary_email=data["email"],
+        )
+        Membership.objects.create(
+            user=user,
+            organization=org,
+            role=Membership.Role.OWNER,
+        )
+        user.active_organization = org
+        user.save(update_fields=["active_organization"])
+        return user
+
+
+class InviteSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    role = serializers.ChoiceField(choices=Membership.Role.choices)
+
+    def validate_role(self, value):
+        if value == Membership.Role.OWNER:
+            raise serializers.ValidationError("Cannot invite users as owners.")
+        return value
+
+
+class ChangePasswordSerializer(serializers.Serializer):
+    current_password = serializers.CharField(write_only=True)
+    new_password = serializers.CharField(write_only=True, min_length=10)
+
+    def validate_new_password(self, value):
+        validate_password(value)
+        return value

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -2,8 +2,24 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
+from apps.accounts.views import (
+    ChangePasswordView,
+    InviteView,
+    LogoutView,
+    MeView,
+    MembersView,
+    SignupView,
+    SwitchOrgView,
+)
+
 urlpatterns = [
     path("login/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("refresh/", TokenRefreshView.as_view(), name="token_refresh"),
-    # TODO: signup, logout, verify-email, verify-phone, me, change-password
+    path("signup/", SignupView.as_view(), name="signup"),
+    path("logout/", LogoutView.as_view(), name="logout"),
+    path("me/", MeView.as_view(), name="me"),
+    path("me/change-password/", ChangePasswordView.as_view(), name="change_password"),
+    path("invite/", InviteView.as_view(), name="invite"),
+    path("members/", MembersView.as_view(), name="members"),
+    path("switch-org/", SwitchOrgView.as_view(), name="switch_org"),
 ]

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -1,0 +1,166 @@
+"""Auth and accounts API views."""
+from django.db import transaction
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.accounts.models import Membership, User
+from apps.accounts.permissions import IsOrgOwner
+from apps.accounts.serializers import (
+    ChangePasswordSerializer,
+    InviteSerializer,
+    MembershipSerializer,
+    SignupSerializer,
+    UserSerializer,
+)
+
+
+class SignupView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = SignupSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+
+        refresh = RefreshToken.for_user(user)
+        return Response(
+            {
+                "user": UserSerializer(user).data,
+                "access": str(refresh.access_token),
+                "refresh": str(refresh),
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+
+class MeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = UserSerializer(request.user)
+        return Response(serializer.data)
+
+    def patch(self, request):
+        serializer = UserSerializer(request.user, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+
+class LogoutView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        try:
+            refresh_token = request.data.get("refresh")
+            if refresh_token:
+                token = RefreshToken(refresh_token)
+                token.blacklist()
+        except Exception:
+            pass
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ChangePasswordView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = ChangePasswordSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        if not request.user.check_password(serializer.validated_data["current_password"]):
+            return Response(
+                {"current_password": ["Wrong password."]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        request.user.set_password(serializer.validated_data["new_password"])
+        request.user.save(update_fields=["password"])
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class InviteView(APIView):
+    """Invite a user to the org. Owner-only."""
+    permission_classes = [IsAuthenticated, IsOrgOwner]
+
+    @transaction.atomic
+    def post(self, request):
+        serializer = InviteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        org = request.user.active_organization
+        if not org:
+            return Response(
+                {"detail": "No active organization."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        email = serializer.validated_data["email"]
+        role = serializer.validated_data["role"]
+
+        # Get or create user
+        user, created = User.objects.get_or_create(
+            email__iexact=email,
+            defaults={"email": email},
+        )
+
+        membership, m_created = Membership.objects.get_or_create(
+            user=user,
+            organization=org,
+            defaults={"role": role},
+        )
+        if not m_created:
+            if membership.is_active:
+                return Response(
+                    {"detail": "User is already a member of this organization."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            membership.role = role
+            membership.is_active = True
+            membership.save(update_fields=["role", "is_active"])
+
+        # TODO: send invite email via Celery task
+        return Response(MembershipSerializer(membership).data, status=status.HTTP_201_CREATED)
+
+
+class MembersView(APIView):
+    """List all members of the current org."""
+    permission_classes = [IsAuthenticated, IsOrgOwner]
+
+    def get(self, request):
+        org = request.user.active_organization
+        if not org:
+            return Response({"results": []})
+        memberships = Membership.objects.filter(organization=org, is_active=True).select_related(
+            "user", "organization"
+        )
+        return Response(MembershipSerializer(memberships, many=True).data)
+
+
+class SwitchOrgView(APIView):
+    """Switch the user's active organization."""
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        org_id = request.data.get("organization_id")
+        if not org_id:
+            return Response(
+                {"detail": "organization_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        membership = Membership.objects.filter(
+            user=request.user,
+            organization_id=org_id,
+            is_active=True,
+        ).first()
+        if not membership:
+            return Response(
+                {"detail": "You are not a member of that organization."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        request.user.active_organization = membership.organization
+        request.user.save(update_fields=["active_organization"])
+        return Response(UserSerializer(request.user).data)

--- a/backend/apps/properties/serializers.py
+++ b/backend/apps/properties/serializers.py
@@ -1,0 +1,122 @@
+"""Serializers for properties, units, and leases."""
+from rest_framework import serializers
+
+from apps.properties.models import Lease, Property, Unit
+
+
+class PropertySerializer(serializers.ModelSerializer):
+    unit_count = serializers.SerializerMethodField()
+    occupied_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Property
+        fields = [
+            "id",
+            "name",
+            "property_type",
+            "address_line1",
+            "address_line2",
+            "city",
+            "state",
+            "postal_code",
+            "country",
+            "electricity_rate_per_unit",
+            "unit_count",
+            "occupied_count",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+    def get_unit_count(self, obj):
+        return obj.units.filter(is_deleted=False).count()
+
+    def get_occupied_count(self, obj):
+        return obj.units.filter(is_deleted=False, status=Unit.Status.OCCUPIED).count()
+
+
+class UnitSerializer(serializers.ModelSerializer):
+    property_name = serializers.CharField(source="property.name", read_only=True)
+
+    class Meta:
+        model = Unit
+        fields = [
+            "id",
+            "property",
+            "property_name",
+            "name",
+            "floor",
+            "area_sqft",
+            "bedrooms",
+            "base_rent",
+            "security_deposit",
+            "electricity_meter_id",
+            "status",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "property_name", "created_at", "updated_at"]
+
+    def validate_property(self, value):
+        request = self.context.get("request")
+        if request and value.organization_id != request.user.active_organization_id:
+            raise serializers.ValidationError("Property does not belong to your organization.")
+        return value
+
+
+class LeaseSerializer(serializers.ModelSerializer):
+    tenant_email = serializers.EmailField(source="tenant.email", read_only=True)
+    unit_name = serializers.CharField(source="unit.name", read_only=True)
+    property_name = serializers.CharField(source="unit.property.name", read_only=True)
+
+    class Meta:
+        model = Lease
+        fields = [
+            "id",
+            "unit",
+            "unit_name",
+            "property_name",
+            "tenant",
+            "tenant_email",
+            "start_date",
+            "end_date",
+            "monthly_rent",
+            "security_deposit_held",
+            "billing_cycle",
+            "billing_day_of_month",
+            "grace_period_days",
+            "late_fee_type",
+            "late_fee_value",
+            "status",
+            "notes",
+            "is_active",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "tenant_email",
+            "unit_name",
+            "property_name",
+            "is_active",
+            "created_at",
+            "updated_at",
+        ]
+
+    def validate_unit(self, value):
+        request = self.context.get("request")
+        if request and value.organization_id != request.user.active_organization_id:
+            raise serializers.ValidationError("Unit does not belong to your organization.")
+        return value
+
+    def validate(self, data):
+        start = data.get("start_date")
+        end = data.get("end_date")
+        if start and end and end <= start:
+            raise serializers.ValidationError({"end_date": "End date must be after start date."})
+        day = data.get("billing_day_of_month", 1)
+        if not (1 <= day <= 28):
+            raise serializers.ValidationError(
+                {"billing_day_of_month": "Billing day must be between 1 and 28."}
+            )
+        return data

--- a/backend/apps/properties/urls.py
+++ b/backend/apps/properties/urls.py
@@ -1,6 +1,14 @@
-"""properties API URLs - TODO: implement viewsets."""
-from django.urls import path
+"""Properties API URLs."""
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from apps.properties.views import LeaseViewSet, PropertyViewSet, UnitViewSet
+
+router = DefaultRouter()
+router.register("", PropertyViewSet, basename="property")
+router.register("units", UnitViewSet, basename="unit")
+router.register("leases", LeaseViewSet, basename="lease")
 
 urlpatterns = [
-    # TODO: add viewset routes
+    path("", include(router.urls)),
 ]

--- a/backend/apps/properties/views.py
+++ b/backend/apps/properties/views.py
@@ -1,0 +1,134 @@
+"""Property, Unit, and Lease CRUD viewsets with tenant scoping."""
+from rest_framework import filters, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from apps.accounts.permissions import IsOrgMember, IsOrgOwnerOrManager
+from apps.properties.models import Lease, Property, Unit
+from apps.properties.serializers import LeaseSerializer, PropertySerializer, UnitSerializer
+
+
+class OrgScopedMixin:
+    """Automatically scope querysets to the user's active organization."""
+
+    def get_org(self):
+        return self.request.user.active_organization
+
+    def get_queryset(self):
+        org = self.get_org()
+        if not org:
+            return self.queryset.none()
+        return self.queryset.filter(organization=org)
+
+    def perform_create(self, serializer):
+        serializer.save(organization=self.get_org())
+
+
+class PropertyViewSet(OrgScopedMixin, viewsets.ModelViewSet):
+    queryset = Property.objects.filter(is_deleted=False)
+    serializer_class = PropertySerializer
+    permission_classes = [IsAuthenticated, IsOrgMember]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name", "city", "state", "address_line1"]
+    ordering_fields = ["name", "city", "created_at"]
+    ordering = ["-created_at"]
+
+    def get_permissions(self):
+        if self.action in ("create", "update", "partial_update", "destroy"):
+            return [IsAuthenticated(), IsOrgOwnerOrManager()]
+        return super().get_permissions()
+
+    def perform_destroy(self, instance):
+        instance.soft_delete()
+
+    @action(detail=True, methods=["get"])
+    def units(self, request, pk=None):
+        prop = self.get_object()
+        units = Unit.objects.filter(property=prop, is_deleted=False)
+        serializer = UnitSerializer(units, many=True, context={"request": request})
+        return Response(serializer.data)
+
+
+class UnitViewSet(OrgScopedMixin, viewsets.ModelViewSet):
+    queryset = Unit.objects.filter(is_deleted=False).select_related("property")
+    serializer_class = UnitSerializer
+    permission_classes = [IsAuthenticated, IsOrgMember]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["name", "property__name", "electricity_meter_id"]
+    ordering_fields = ["name", "base_rent", "status", "created_at"]
+    ordering = ["property__name", "name"]
+
+    def get_permissions(self):
+        if self.action in ("create", "update", "partial_update", "destroy"):
+            return [IsAuthenticated(), IsOrgOwnerOrManager()]
+        return super().get_permissions()
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        property_id = self.request.query_params.get("property")
+        if property_id:
+            qs = qs.filter(property_id=property_id)
+        status_filter = self.request.query_params.get("status")
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+        return qs
+
+    def perform_destroy(self, instance):
+        instance.soft_delete()
+
+
+class LeaseViewSet(OrgScopedMixin, viewsets.ModelViewSet):
+    queryset = Lease.objects.all().select_related("unit__property", "tenant")
+    serializer_class = LeaseSerializer
+    permission_classes = [IsAuthenticated, IsOrgMember]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["tenant__email", "tenant__first_name", "tenant__last_name", "unit__name"]
+    ordering_fields = ["start_date", "end_date", "monthly_rent", "status", "created_at"]
+    ordering = ["-created_at"]
+
+    def get_permissions(self):
+        if self.action in ("create", "update", "partial_update", "destroy"):
+            return [IsAuthenticated(), IsOrgOwnerOrManager()]
+        return super().get_permissions()
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        status_filter = self.request.query_params.get("status")
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+        unit_id = self.request.query_params.get("unit")
+        if unit_id:
+            qs = qs.filter(unit_id=unit_id)
+        tenant_id = self.request.query_params.get("tenant")
+        if tenant_id:
+            qs = qs.filter(tenant_id=tenant_id)
+        return qs
+
+    @action(detail=True, methods=["post"])
+    def activate(self, request, pk=None):
+        lease = self.get_object()
+        if lease.status != Lease.Status.DRAFT:
+            return Response(
+                {"detail": "Only draft leases can be activated."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        lease.status = Lease.Status.ACTIVE
+        lease.save(update_fields=["status"])
+        lease.unit.status = Unit.Status.OCCUPIED
+        lease.unit.save(update_fields=["status"])
+        return Response(LeaseSerializer(lease).data)
+
+    @action(detail=True, methods=["post"])
+    def terminate(self, request, pk=None):
+        lease = self.get_object()
+        if lease.status not in (Lease.Status.ACTIVE, Lease.Status.DRAFT):
+            return Response(
+                {"detail": "Only active or draft leases can be terminated."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        lease.status = Lease.Status.TERMINATED
+        lease.save(update_fields=["status"])
+        lease.unit.status = Unit.Status.VACANT
+        lease.unit.save(update_fields=["status"])
+        return Response(LeaseSerializer(lease).data)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,9 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from '@/pages/LoginPage';
+import SignupPage from '@/pages/SignupPage';
 import DashboardPage from '@/pages/DashboardPage';
+import PropertiesPage from '@/pages/PropertiesPage';
+import PropertyDetailPage from '@/pages/PropertyDetailPage';
 import { useAuthStore } from '@/store/auth';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -12,11 +15,28 @@ export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/signup" element={<SignupPage />} />
       <Route
         path="/dashboard"
         element={
           <ProtectedRoute>
             <DashboardPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/properties"
+        element={
+          <ProtectedRoute>
+            <PropertiesPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/properties/:id"
+        element={
+          <ProtectedRoute>
+            <PropertyDetailPage />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,0 +1,64 @@
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/store/auth';
+
+const nav = [
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/properties', label: 'Properties' },
+];
+
+export default function AppShell({ children }: { children: React.ReactNode }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { user, logout } = useAuthStore();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <header className="bg-white border-b border-gray-200 px-6 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-8">
+          <span className="font-bold text-gray-900 text-lg">RentTrack</span>
+          <nav className="flex items-center gap-1">
+            {nav.map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                  location.pathname.startsWith(to)
+                    ? 'bg-blue-50 text-blue-700'
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="flex items-center gap-4">
+          {user?.active_organization && (
+            <span className="text-sm text-gray-500">{user.active_organization.name}</span>
+          )}
+          <div className="relative group">
+            <button className="flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900">
+              <span className="h-8 w-8 rounded-full bg-blue-100 text-blue-700 font-semibold flex items-center justify-center text-xs">
+                {user?.first_name?.[0]?.toUpperCase() ?? user?.email?.[0]?.toUpperCase() ?? '?'}
+              </span>
+            </button>
+            <div className="absolute right-0 top-full mt-1 w-40 bg-white rounded-lg shadow-lg border border-gray-200 py-1 hidden group-hover:block z-10">
+              <button
+                onClick={handleLogout}
+                className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                Sign out
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+      <main className="flex-1 px-6 py-8 max-w-6xl mx-auto w-full">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,44 @@
+import { forwardRef } from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  loading?: boolean;
+}
+
+const variants = {
+  primary: 'bg-blue-700 text-white hover:bg-blue-800 disabled:bg-blue-300',
+  secondary: 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50',
+  danger: 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300',
+  ghost: 'text-gray-600 hover:bg-gray-100',
+};
+
+const sizes = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-2.5 text-base',
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', size = 'md', loading, disabled, children, className = '', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={`inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${variants[variant]} ${sizes[size]} ${className}`}
+        {...props}
+      >
+        {loading && (
+          <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+        )}
+        {children}
+      </button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
+export default Button;

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,38 @@
+import { forwardRef } from 'react';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  hint?: string;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, hint, className = '', id, ...props }, ref) => {
+    const inputId = id || label?.toLowerCase().replace(/\s+/g, '-');
+    return (
+      <div className="space-y-1">
+        {label && (
+          <label htmlFor={inputId} className="block text-sm font-medium text-gray-700">
+            {label}
+            {props.required && <span className="ml-0.5 text-red-500">*</span>}
+          </label>
+        )}
+        <input
+          ref={ref}
+          id={inputId}
+          className={`block w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+            error
+              ? 'border-red-400 focus:ring-red-400'
+              : 'border-gray-300 focus:border-blue-400'
+          } ${className}`}
+          {...props}
+        />
+        {error && <p className="text-xs text-red-600">{error}</p>}
+        {hint && !error && <p className="text-xs text-gray-500">{hint}</p>}
+      </div>
+    );
+  },
+);
+
+Input.displayName = 'Input';
+export default Input;

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizes = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+};
+
+export default function Modal({ open, onClose, title, children, size = 'md' }: ModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div
+        className={`relative w-full ${sizes[size]} rounded-2xl bg-white shadow-xl`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+      >
+        <div className="flex items-center justify-between border-b px-6 py-4">
+          <h2 id="modal-title" className="text-lg font-semibold text-gray-900">
+            {title}
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            aria-label="Close"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="px-6 py-5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { create } from 'zustand';
+
+type ToastType = 'success' | 'error' | 'info';
+
+interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastStore {
+  toasts: Toast[];
+  add: (message: string, type?: ToastType) => void;
+  remove: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+  add: (message, type = 'info') => {
+    const id = Math.random().toString(36).slice(2);
+    set((s) => ({ toasts: [...s.toasts, { id, message, type }] }));
+    setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, 4000);
+  },
+  remove: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));
+
+export const toast = {
+  success: (msg: string) => useToastStore.getState().add(msg, 'success'),
+  error: (msg: string) => useToastStore.getState().add(msg, 'error'),
+  info: (msg: string) => useToastStore.getState().add(msg, 'info'),
+};
+
+const icons: Record<ToastType, string> = {
+  success: '✓',
+  error: '✕',
+  info: 'ℹ',
+};
+
+const colors: Record<ToastType, string> = {
+  success: 'bg-green-50 border-green-400 text-green-800',
+  error: 'bg-red-50 border-red-400 text-red-800',
+  info: 'bg-blue-50 border-blue-400 text-blue-800',
+};
+
+function ToastItem({ toast: t }: { toast: Toast }) {
+  const remove = useToastStore((s) => s.remove);
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-lg border px-4 py-3 shadow-md ${colors[t.type]}`}
+    >
+      <span className="mt-0.5 font-bold">{icons[t.type]}</span>
+      <p className="flex-1 text-sm">{t.message}</p>
+      <button onClick={() => remove(t.id)} className="ml-2 opacity-60 hover:opacity-100">
+        ×
+      </button>
+    </div>
+  );
+}
+
+export default function Toaster() {
+  const toasts = useToastStore((s) => s.toasts);
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-80">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useProperties.ts
+++ b/frontend/src/hooks/useProperties.ts
@@ -1,0 +1,100 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type { PaginatedResponse, Property, Unit, Lease } from '@/types';
+
+export function useProperties() {
+  return useQuery({
+    queryKey: ['properties'],
+    queryFn: async () => {
+      const { data } = await api.get<PaginatedResponse<Property>>('/properties/');
+      return data;
+    },
+  });
+}
+
+export function useProperty(id: string) {
+  return useQuery({
+    queryKey: ['properties', id],
+    queryFn: async () => {
+      const { data } = await api.get<Property>(`/properties/${id}/`);
+      return data;
+    },
+    enabled: !!id,
+  });
+}
+
+export function usePropertyUnits(propertyId: string) {
+  return useQuery({
+    queryKey: ['properties', propertyId, 'units'],
+    queryFn: async () => {
+      const { data } = await api.get<Unit[]>(`/properties/${propertyId}/units/`);
+      return data;
+    },
+    enabled: !!propertyId,
+  });
+}
+
+export function useCreateProperty() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: Partial<Property>) => api.post('/properties/', payload).then((r) => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['properties'] }),
+  });
+}
+
+export function useUpdateProperty(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: Partial<Property>) =>
+      api.patch(`/properties/${id}/`, payload).then((r) => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['properties'] });
+      qc.invalidateQueries({ queryKey: ['properties', id] });
+    },
+  });
+}
+
+export function useDeleteProperty() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/properties/${id}/`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['properties'] }),
+  });
+}
+
+export function useUnits(propertyId?: string) {
+  return useQuery({
+    queryKey: ['units', { propertyId }],
+    queryFn: async () => {
+      const params = propertyId ? `?property=${propertyId}` : '';
+      const { data } = await api.get<PaginatedResponse<Unit>>(`/properties/units/${params}`);
+      return data;
+    },
+  });
+}
+
+export function useCreateUnit() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: Partial<Unit>) =>
+      api.post('/properties/units/', payload).then((r) => r.data),
+    onSuccess: (data: Unit) => {
+      qc.invalidateQueries({ queryKey: ['units'] });
+      qc.invalidateQueries({ queryKey: ['properties', data.property, 'units'] });
+      qc.invalidateQueries({ queryKey: ['properties', data.property] });
+    },
+  });
+}
+
+export function useLeases(filters: { unit?: string; tenant?: string; status?: string } = {}) {
+  return useQuery({
+    queryKey: ['leases', filters],
+    queryFn: async () => {
+      const params = new URLSearchParams(filters as Record<string, string>).toString();
+      const { data } = await api.get<PaginatedResponse<Lease>>(
+        `/properties/leases/${params ? `?${params}` : ''}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
+import Toaster from './components/ui/Toast';
 import './index.css';
 
 const queryClient = new QueryClient({
@@ -19,6 +20,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <App />
+        <Toaster />
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,25 +1,85 @@
+import { Link } from 'react-router-dom';
+import AppShell from '@/components/layout/AppShell';
+import { useProperties } from '@/hooks/useProperties';
 import { useAuthStore } from '@/store/auth';
 
 export default function DashboardPage() {
-  const logout = useAuthStore((s) => s.logout);
+  const user = useAuthStore((s) => s.user);
+  const { data: properties, isLoading } = useProperties();
+
+  const totalUnits = properties?.results.reduce((sum, p) => sum + p.unit_count, 0) ?? 0;
+  const occupiedUnits = properties?.results.reduce((sum, p) => sum + p.occupied_count, 0) ?? 0;
+  const vacantUnits = totalUnits - occupiedUnits;
 
   return (
-    <div className="min-h-screen">
-      <header className="bg-white border-b px-6 py-4 flex justify-between items-center">
-        <h1 className="text-xl font-bold text-brand-900">RentTrack</h1>
-        <button
-          onClick={logout}
-          className="text-sm text-gray-600 hover:text-gray-900"
-        >
-          Sign out
-        </button>
-      </header>
-      <main className="p-6 max-w-7xl mx-auto">
-        <h2 className="text-2xl font-semibold mb-4">Dashboard</h2>
-        <p className="text-gray-500">
-          TODO: properties summary, outstanding dues, recent activity.
-        </p>
-      </main>
-    </div>
+    <AppShell>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">
+          Welcome back{user?.first_name ? `, ${user.first_name}` : ''}
+        </h1>
+        <p className="text-gray-500 mt-1">Here's an overview of your portfolio.</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        {[
+          { label: 'Properties', value: properties?.count ?? 0, href: '/properties' },
+          { label: 'Total units', value: totalUnits, href: '/properties' },
+          { label: 'Vacant units', value: vacantUnits, href: '/properties' },
+        ].map(({ label, value, href }) => (
+          <Link
+            key={label}
+            to={href}
+            className="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-md transition-shadow"
+          >
+            <p className="text-sm text-gray-500">{label}</p>
+            {isLoading ? (
+              <div className="h-8 w-16 bg-gray-100 animate-pulse rounded mt-1" />
+            ) : (
+              <p className="text-3xl font-bold text-gray-900 mt-1">{value}</p>
+            )}
+          </Link>
+        ))}
+      </div>
+
+      {!isLoading && properties && properties.results.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+            <h2 className="font-semibold text-gray-900">Recent properties</h2>
+            <Link to="/properties" className="text-sm text-blue-700 hover:underline">
+              View all
+            </Link>
+          </div>
+          <div className="divide-y divide-gray-100">
+            {properties.results.slice(0, 5).map((p) => (
+              <Link
+                key={p.id}
+                to={`/properties/${p.id}`}
+                className="flex items-center justify-between px-5 py-3 hover:bg-gray-50"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-900">{p.name}</p>
+                  <p className="text-xs text-gray-500">{p.city}, {p.state}</p>
+                </div>
+                <span className="text-sm text-gray-500">
+                  {p.occupied_count}/{p.unit_count} occupied
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!isLoading && properties?.count === 0 && (
+        <div className="rounded-xl border-2 border-dashed border-gray-300 p-12 text-center">
+          <p className="text-gray-500 mb-4">No properties yet. Start by adding your first property.</p>
+          <Link
+            to="/properties"
+            className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-blue-700 text-white text-sm font-medium hover:bg-blue-800 transition-colors"
+          >
+            Go to Properties
+          </Link>
+        </div>
+      )}
+    </AppShell>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/store/auth';
 
 export default function LoginPage() {
@@ -59,6 +59,12 @@ export default function LoginPage() {
             {loading ? 'Signing in...' : 'Sign in'}
           </button>
         </form>
+        <p className="mt-6 text-center text-sm text-gray-500">
+          Don't have an account?{' '}
+          <Link to="/signup" className="font-medium text-blue-700 hover:underline">
+            Create one
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/PropertiesPage.tsx
+++ b/frontend/src/pages/PropertiesPage.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import AppShell from '@/components/layout/AppShell';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import Modal from '@/components/ui/Modal';
+import { toast } from '@/components/ui/Toast';
+import { useProperties, useCreateProperty } from '@/hooks/useProperties';
+import type { Property } from '@/types';
+
+function PropertyCard({ property }: { property: Property }) {
+  const occupancy =
+    property.unit_count > 0
+      ? Math.round((property.occupied_count / property.unit_count) * 100)
+      : 0;
+
+  return (
+    <Link
+      to={`/properties/${property.id}`}
+      className="block bg-white rounded-xl border border-gray-200 p-5 hover:shadow-md hover:border-blue-200 transition-all"
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <h3 className="font-semibold text-gray-900">{property.name}</h3>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {property.city}, {property.state}
+          </p>
+        </div>
+        <span className="text-xs font-medium px-2 py-1 rounded-full bg-gray-100 text-gray-600 capitalize">
+          {property.property_type}
+        </span>
+      </div>
+      <p className="text-sm text-gray-500 mb-4 truncate">{property.address_line1}</p>
+      <div className="flex items-center justify-between text-sm">
+        <div className="text-gray-600">
+          <span className="font-medium text-gray-900">{property.occupied_count}</span>
+          /{property.unit_count} units occupied
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-24 h-1.5 rounded-full bg-gray-200">
+            <div
+              className="h-1.5 rounded-full bg-blue-500"
+              style={{ width: `${occupancy}%` }}
+            />
+          </div>
+          <span className="text-gray-500 text-xs">{occupancy}%</span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+interface PropertyFormData {
+  name: string;
+  property_type: 'residential' | 'commercial' | 'mixed';
+  address_line1: string;
+  address_line2: string;
+  city: string;
+  state: string;
+  postal_code: string;
+}
+
+function AddPropertyModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const createProperty = useCreateProperty();
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<PropertyFormData>();
+
+  const onSubmit = async (data: PropertyFormData) => {
+    try {
+      await createProperty.mutateAsync(data);
+      toast.success('Property created successfully');
+      reset();
+      onClose();
+    } catch (err: any) {
+      const msg = err?.response?.data?.detail ?? 'Failed to create property';
+      toast.error(msg);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Add property" size="lg">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="col-span-2">
+            <Input
+              label="Property name"
+              {...register('name', { required: 'Name is required' })}
+              error={errors.name?.message}
+            />
+          </div>
+          <div className="col-span-2">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Type <span className="text-red-500">*</span>
+            </label>
+            <select
+              {...register('property_type', { required: true })}
+              className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="residential">Residential</option>
+              <option value="commercial">Commercial</option>
+              <option value="mixed">Mixed Use</option>
+            </select>
+          </div>
+          <div className="col-span-2">
+            <Input
+              label="Address line 1"
+              {...register('address_line1', { required: 'Address is required' })}
+              error={errors.address_line1?.message}
+            />
+          </div>
+          <div className="col-span-2">
+            <Input label="Address line 2" {...register('address_line2')} />
+          </div>
+          <Input
+            label="City"
+            {...register('city', { required: 'City is required' })}
+            error={errors.city?.message}
+          />
+          <Input
+            label="State"
+            {...register('state', { required: 'State is required' })}
+            error={errors.state?.message}
+          />
+          <Input
+            label="Postal code"
+            {...register('postal_code', { required: 'Postal code is required' })}
+            error={errors.postal_code?.message}
+          />
+        </div>
+        <div className="flex justify-end gap-3 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" loading={createProperty.isPending}>
+            Create property
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export default function PropertiesPage() {
+  const [showAdd, setShowAdd] = useState(false);
+  const { data, isLoading, isError } = useProperties();
+
+  return (
+    <AppShell>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Properties</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            {data?.count ?? 0} propert{data?.count === 1 ? 'y' : 'ies'}
+          </p>
+        </div>
+        <Button onClick={() => setShowAdd(true)}>+ Add property</Button>
+      </div>
+
+      {isLoading && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-40 rounded-xl bg-gray-100 animate-pulse" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="rounded-xl bg-red-50 border border-red-200 p-6 text-center text-sm text-red-700">
+          Failed to load properties. Please refresh and try again.
+        </div>
+      )}
+
+      {!isLoading && !isError && data?.results.length === 0 && (
+        <div className="rounded-xl border-2 border-dashed border-gray-300 p-12 text-center">
+          <p className="text-gray-500 mb-4">No properties yet</p>
+          <Button onClick={() => setShowAdd(true)}>Add your first property</Button>
+        </div>
+      )}
+
+      {!isLoading && !isError && data && data.results.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {data.results.map((p) => (
+            <PropertyCard key={p.id} property={p} />
+          ))}
+        </div>
+      )}
+
+      <AddPropertyModal open={showAdd} onClose={() => setShowAdd(false)} />
+    </AppShell>
+  );
+}

--- a/frontend/src/pages/PropertyDetailPage.tsx
+++ b/frontend/src/pages/PropertyDetailPage.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import AppShell from '@/components/layout/AppShell';
+import Button from '@/components/ui/Button';
+import Modal from '@/components/ui/Modal';
+import Input from '@/components/ui/Input';
+import { toast } from '@/components/ui/Toast';
+import { useProperty, usePropertyUnits, useCreateUnit } from '@/hooks/useProperties';
+import type { Unit } from '@/types';
+
+const statusColors: Record<Unit['status'], string> = {
+  vacant: 'bg-green-100 text-green-700',
+  occupied: 'bg-blue-100 text-blue-700',
+  maintenance: 'bg-yellow-100 text-yellow-700',
+};
+
+function UnitRow({ unit }: { unit: Unit }) {
+  return (
+    <tr className="border-b border-gray-100 hover:bg-gray-50">
+      <td className="py-3 px-4 text-sm font-medium text-gray-900">{unit.name}</td>
+      <td className="py-3 px-4 text-sm text-gray-600">{unit.floor ?? '—'}</td>
+      <td className="py-3 px-4 text-sm text-gray-600">{unit.bedrooms ?? '—'}</td>
+      <td className="py-3 px-4 text-sm text-gray-600">
+        ₹{Number(unit.base_rent).toLocaleString('en-IN')}
+      </td>
+      <td className="py-3 px-4">
+        <span className={`text-xs font-medium px-2 py-1 rounded-full capitalize ${statusColors[unit.status]}`}>
+          {unit.status}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+interface UnitFormData {
+  name: string;
+  floor: string;
+  bedrooms: string;
+  area_sqft: string;
+  base_rent: string;
+  security_deposit: string;
+  electricity_meter_id: string;
+}
+
+function AddUnitModal({
+  open,
+  onClose,
+  propertyId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  propertyId: string;
+}) {
+  const createUnit = useCreateUnit();
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<UnitFormData>();
+
+  const onSubmit = async (data: UnitFormData) => {
+    try {
+      await createUnit.mutateAsync({
+        property: propertyId,
+        name: data.name,
+        floor: data.floor ? Number(data.floor) : undefined,
+        bedrooms: data.bedrooms ? Number(data.bedrooms) : undefined,
+        area_sqft: data.area_sqft || undefined,
+        base_rent: data.base_rent,
+        security_deposit: data.security_deposit || '0',
+        electricity_meter_id: data.electricity_meter_id,
+      } as any);
+      toast.success('Unit added');
+      reset();
+      onClose();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.detail ?? 'Failed to add unit');
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Add unit">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <Input
+          label="Unit name"
+          placeholder="e.g. Flat 3B"
+          {...register('name', { required: 'Unit name is required' })}
+          error={errors.name?.message}
+        />
+        <div className="grid grid-cols-2 gap-4">
+          <Input label="Floor" type="number" {...register('floor')} />
+          <Input label="Bedrooms" type="number" {...register('bedrooms')} />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <Input label="Area (sqft)" type="number" {...register('area_sqft')} />
+          <Input
+            label="Monthly rent (₹)"
+            type="number"
+            {...register('base_rent', { required: 'Rent is required' })}
+            error={errors.base_rent?.message}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <Input label="Security deposit (₹)" type="number" {...register('security_deposit')} />
+          <Input label="Electricity meter ID" {...register('electricity_meter_id')} />
+        </div>
+        <div className="flex justify-end gap-3 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" loading={createUnit.isPending}>
+            Add unit
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export default function PropertyDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [showAddUnit, setShowAddUnit] = useState(false);
+  const { data: property, isLoading: propLoading } = useProperty(id!);
+  const { data: units, isLoading: unitsLoading } = usePropertyUnits(id!);
+
+  if (propLoading) {
+    return (
+      <AppShell>
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-48" />
+          <div className="h-4 bg-gray-100 rounded w-80" />
+        </div>
+      </AppShell>
+    );
+  }
+
+  if (!property) {
+    return (
+      <AppShell>
+        <p className="text-gray-500">Property not found.</p>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-1">
+        <Link to="/properties" className="text-sm text-gray-500 hover:text-gray-700">
+          ← Properties
+        </Link>
+      </div>
+      <div className="flex items-start justify-between mb-6 mt-2">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{property.name}</h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {property.address_line1}
+            {property.address_line2 ? `, ${property.address_line2}` : ''},{' '}
+            {property.city}, {property.state} {property.postal_code}
+          </p>
+        </div>
+        <span className="text-sm font-medium px-3 py-1 rounded-full bg-gray-100 text-gray-600 capitalize">
+          {property.property_type}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mb-8">
+        {[
+          { label: 'Total units', value: property.unit_count },
+          { label: 'Occupied', value: property.occupied_count },
+          { label: 'Vacant', value: property.unit_count - property.occupied_count },
+        ].map(({ label, value }) => (
+          <div key={label} className="bg-white rounded-xl border border-gray-200 p-4">
+            <p className="text-sm text-gray-500">{label}</p>
+            <p className="text-2xl font-bold text-gray-900 mt-1">{value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+          <h2 className="font-semibold text-gray-900">Units</h2>
+          <Button size="sm" onClick={() => setShowAddUnit(true)}>
+            + Add unit
+          </Button>
+        </div>
+
+        {unitsLoading ? (
+          <div className="p-8 text-center text-sm text-gray-400">Loading units…</div>
+        ) : units && units.length > 0 ? (
+          <table className="w-full">
+            <thead className="bg-gray-50 text-xs text-gray-500 uppercase tracking-wider">
+              <tr>
+                <th className="py-2 px-4 text-left font-medium">Unit</th>
+                <th className="py-2 px-4 text-left font-medium">Floor</th>
+                <th className="py-2 px-4 text-left font-medium">Beds</th>
+                <th className="py-2 px-4 text-left font-medium">Rent</th>
+                <th className="py-2 px-4 text-left font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {units.map((u) => (
+                <UnitRow key={u.id} unit={u} />
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="p-8 text-center">
+            <p className="text-gray-500 text-sm mb-3">No units yet</p>
+            <Button size="sm" onClick={() => setShowAddUnit(true)}>
+              Add first unit
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <AddUnitModal
+        open={showAddUnit}
+        onClose={() => setShowAddUnit(false)}
+        propertyId={id!}
+      />
+    </AppShell>
+  );
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/store/auth';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+
+export default function SignupPage() {
+  const navigate = useNavigate();
+  const signup = useAuthStore((s) => s.signup);
+
+  const [form, setForm] = useState({
+    email: '',
+    password: '',
+    first_name: '',
+    last_name: '',
+    org_name: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+
+  const set = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((f) => ({ ...f, [field]: e.target.value }));
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrors({});
+    setLoading(true);
+    try {
+      await signup(form);
+      navigate('/dashboard');
+    } catch (err: any) {
+      const data = err?.response?.data ?? {};
+      const mapped: Record<string, string> = {};
+      for (const [k, v] of Object.entries(data)) {
+        mapped[k] = Array.isArray(v) ? v[0] : String(v);
+      }
+      if (Object.keys(mapped).length === 0) {
+        mapped.form = 'Something went wrong. Please try again.';
+      }
+      setErrors(mapped);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">RentTrack</h1>
+          <p className="mt-1 text-gray-500">Create your landlord account</p>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+          <form onSubmit={onSubmit} className="space-y-5">
+            <div className="grid grid-cols-2 gap-4">
+              <Input
+                label="First name"
+                value={form.first_name}
+                onChange={set('first_name')}
+                required
+                autoComplete="given-name"
+                error={errors.first_name}
+              />
+              <Input
+                label="Last name"
+                value={form.last_name}
+                onChange={set('last_name')}
+                autoComplete="family-name"
+                error={errors.last_name}
+              />
+            </div>
+
+            <Input
+              label="Work email"
+              type="email"
+              value={form.email}
+              onChange={set('email')}
+              required
+              autoComplete="email"
+              error={errors.email}
+            />
+
+            <Input
+              label="Password"
+              type="password"
+              value={form.password}
+              onChange={set('password')}
+              required
+              autoComplete="new-password"
+              hint="Minimum 10 characters"
+              error={errors.password}
+            />
+
+            <Input
+              label="Organization / Company name"
+              value={form.org_name}
+              onChange={set('org_name')}
+              required
+              placeholder="e.g. Sharma Properties"
+              error={errors.org_name}
+            />
+
+            {errors.form && (
+              <p className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+                {errors.form}
+              </p>
+            )}
+
+            <Button type="submit" loading={loading} className="w-full" size="lg">
+              Create account
+            </Button>
+          </form>
+
+          <p className="mt-6 text-center text-sm text-gray-500">
+            Already have an account?{' '}
+            <Link to="/login" className="font-medium text-blue-700 hover:underline">
+              Sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -1,14 +1,26 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import axios from 'axios';
+import type { User } from '@/types';
 
 interface AuthState {
   accessToken: string | null;
   refreshToken: string | null;
-  user: { id: string; email: string } | null;
+  user: User | null;
   login: (email: string, password: string) => Promise<void>;
-  logout: () => void;
+  signup: (data: SignupData) => Promise<void>;
+  logout: () => Promise<void>;
   refresh: () => Promise<string | null>;
+  fetchMe: () => Promise<void>;
+  setUser: (user: User) => void;
+}
+
+interface SignupData {
+  email: string;
+  password: string;
+  first_name: string;
+  last_name?: string;
+  org_name: string;
 }
 
 const API = import.meta.env.VITE_API_URL || '/api/v1';
@@ -22,13 +34,37 @@ export const useAuthStore = create<AuthState>()(
 
       login: async (email, password) => {
         const { data } = await axios.post(`${API}/auth/login/`, { email, password });
-        set({
-          accessToken: data.access,
-          refreshToken: data.refresh,
-        });
+        set({ accessToken: data.access, refreshToken: data.refresh });
+        // Fetch user profile after login
+        try {
+          const me = await axios.get(`${API}/auth/me/`, {
+            headers: { Authorization: `Bearer ${data.access}` },
+          });
+          set({ user: me.data });
+        } catch {
+          // Non-fatal — user will be fetched on next page load
+        }
       },
 
-      logout: () => {
+      signup: async (signupData) => {
+        const { data } = await axios.post(`${API}/auth/signup/`, signupData);
+        set({ accessToken: data.access, refreshToken: data.refresh, user: data.user });
+      },
+
+      logout: async () => {
+        const refreshToken = get().refreshToken;
+        const accessToken = get().accessToken;
+        if (refreshToken && accessToken) {
+          try {
+            await axios.post(
+              `${API}/auth/logout/`,
+              { refresh: refreshToken },
+              { headers: { Authorization: `Bearer ${accessToken}` } },
+            );
+          } catch {
+            // Blacklist failure is non-fatal
+          }
+        }
         set({ accessToken: null, refreshToken: null, user: null });
       },
 
@@ -36,16 +72,29 @@ export const useAuthStore = create<AuthState>()(
         const refreshToken = get().refreshToken;
         if (!refreshToken) return null;
         try {
-          const { data } = await axios.post(`${API}/auth/refresh/`, {
-            refresh: refreshToken,
-          });
+          const { data } = await axios.post(`${API}/auth/refresh/`, { refresh: refreshToken });
           set({ accessToken: data.access });
           return data.access;
         } catch {
-          set({ accessToken: null, refreshToken: null });
+          set({ accessToken: null, refreshToken: null, user: null });
           return null;
         }
       },
+
+      fetchMe: async () => {
+        const token = get().accessToken;
+        if (!token) return;
+        try {
+          const { data } = await axios.get(`${API}/auth/me/`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          set({ user: data });
+        } catch {
+          // Ignore
+        }
+      },
+
+      setUser: (user) => set({ user }),
     }),
     { name: 'renttrack-auth' },
   ),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,98 @@
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  tier: 'shared' | 'pooled' | 'dedicated';
+  primary_email: string;
+  primary_phone?: string;
+  gstin?: string;
+  pan?: string;
+}
+
+export interface Membership {
+  id: string;
+  organization: Organization;
+  role: 'owner' | 'property_manager' | 'accountant' | 'support' | 'tenant' | 'co_tenant';
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  phone?: string;
+  phone_verified: boolean;
+  email_verified: boolean;
+  active_organization: Organization | null;
+  memberships: Membership[];
+}
+
+export interface Property {
+  id: string;
+  name: string;
+  property_type: 'residential' | 'commercial' | 'mixed';
+  address_line1: string;
+  address_line2?: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country: string;
+  electricity_rate_per_unit: string;
+  unit_count: number;
+  occupied_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Unit {
+  id: string;
+  property: string;
+  property_name: string;
+  name: string;
+  floor?: number | null;
+  area_sqft?: string | null;
+  bedrooms?: number | null;
+  base_rent: string;
+  security_deposit: string;
+  electricity_meter_id?: string;
+  status: 'vacant' | 'occupied' | 'maintenance';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Lease {
+  id: string;
+  unit: string;
+  unit_name: string;
+  property_name: string;
+  tenant: string;
+  tenant_email: string;
+  start_date: string;
+  end_date?: string | null;
+  monthly_rent: string;
+  security_deposit_held: string;
+  billing_cycle: 'monthly' | 'quarterly' | 'yearly';
+  billing_day_of_month: number;
+  grace_period_days: number;
+  late_fee_type: 'flat' | 'percentage' | 'none';
+  late_fee_value: string;
+  status: 'draft' | 'active' | 'ended' | 'terminated';
+  notes?: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}
+
+export interface ApiError {
+  detail?: string;
+  [key: string]: string | string[] | undefined;
+}


### PR DESCRIPTION
Backend:
- accounts: signup (user + org + owner membership, atomic), me, logout (token blacklist), invite, members list, switch-org, change-password
- accounts: RBAC permission classes (IsOrgMember, IsOrgOwner, IsOrgOwnerOrManager)
- properties: PropertyViewSet, UnitViewSet, LeaseViewSet — all tenant-scoped via OrgScopedMixin; lease activate/terminate actions sync unit status
- properties: serializers with cross-org boundary validation

Frontend:
- TypeScript interfaces for all entities (User, Org, Property, Unit, Lease)
- UI primitives: Button, Input, Modal, Toast (global toast helper)
- AppShell layout with nav, active-org display, user avatar dropdown
- Auth store: added signup, server-side logout, fetchMe
- React Query hooks for properties, units, leases (CRUD + cache invalidation)
- SignupPage, PropertiesPage (grid + add modal), PropertyDetailPage (unit table + add modal), DashboardPage (portfolio stats + recent properties)
- App router wired for /signup, /properties, /properties/:id

# Summary
<!-- What does this PR change? -->

## Related issue
Closes #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / Infra

## Checklist
- [ ] Code follows the project style
- [ ] Tests added / updated
- [ ] `pytest` / `npm test` passes locally
- [ ] Documentation updated (README, docs/, API spec)
- [ ] Migrations are backward-compatible (no data loss)
- [ ] Feature is scoped correctly to tenant (no cross-tenant leaks)
- [ ] Secrets are not committed

## Screenshots / demo
<!-- For UI changes -->

## Notes for reviewer
<!-- Anything non-obvious? Trade-offs made? -->
